### PR TITLE
version bump django and other dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,20 @@
-Django==2.1.11
-django-redis==4.10.0
+Django==2.1.15
+django-redis==4.11.0
 # mysql client on OS X needs an install from source with:
 # CFLAGS = -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform
 elo==0.1.1
-mysqlclient==1.4.2.post1
-redis==3.3.8
+mysqlclient==1.4.6
+redis==3.3.11
 uWSGI==2.0.18
 
 # indirect dependencies
 flake8==3.7.5
 mccabe==0.6.1
-mock==2.0.0
-pbr==5.1.1
+mock==3.0.5
+pbr==5.4.4
 pycodestyle==2.5.0
 pyflakes==2.1.0
-pytz==2018.9
-six==1.12.0
+pytz==2019.3
+six==1.13.0
 str2bool==1.1
-urllib3==1.25.3
+urllib3==1.25.7


### PR DESCRIPTION
address this: https://github.com/paul-krohn/django-pool-stats/network/alert/requirements.txt/django/open