### PR TITLE
Elo skip season

### DIFF
--- a/pool/stats/templates/stats/player_elo.html
+++ b/pool/stats/templates/stats/player_elo.html
@@ -5,7 +5,7 @@
 <h2>{{ player }}</h2>
 
 <div class="pull-right search"><input id="filter" class="form-control" type="search" placeholder="Opponent filter"></div>
-<table class="table table-responsive" data-toggle="table" data-sort-order="asc" data-sort-name="date" id="player_elo_history">
+<table class="table table-responsive" data-toggle="table" data-sort-order="desc" data-sort-name="Date" id="player_elo_history">
     <thead>
         <tr>
             <th data-sortable="true" data-field="Date">Date</th>


### PR DESCRIPTION
Fixes a bug where players who skip a season get their Elo rating reset to the default/starter rating. Leaves unaddressed fixing all the ratings.